### PR TITLE
fixed narrow screen callout card icon placement

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -193,13 +193,16 @@ li {
 }
 
 .section-icon {
-  margin-bottom: -3px;
+  margin-bottom: 10px;
   margin-right: calc(var(--spacing) / 2);
+  display: block;
 }
 
 @media all and (min-width: 900px) {
   .section-icon {
     margin-left: calc(-2 * var(--spacing));
+    margin-bottom: -3px;
+    display: inline;
   }
 }
 


### PR DESCRIPTION
On narrow screens, the callout card icon now sits above the h2 tag instead of inline.