### PR TITLE
Add clearer download disclaimer

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -115,6 +115,7 @@ li {
   font-size: 16px;
   background-color: #ebf5ff;
   border-radius: 10px;
+  margin-top: 0;
 }
 
 @media all and (min-width: 900px) {

--- a/index.html
+++ b/index.html
@@ -63,6 +63,16 @@
           volunteers in order to help Canadians and the rest of the world safely
           return to work.
         </p>
+
+        <div class="disclaimer">
+          <h2>How can I download and use COVID Shield?</h2>
+          <p><strong>COVID Shield is not currently available for download or use.</strong></p>
+          <p class="subdued">COVID Shield is provided as a reference for your local public health authority to build their own
+            app. If you are
+            interested in using COVID Shield, please contact your local government representative and ask what they are doing
+            about exposure notification for COVID-19.</p>
+        </div>
+
         <div class="button-group">
           <a
             class="button button--inverted"
@@ -89,10 +99,6 @@
         <div class="demo">
           <div class="notification"></div>
         </div>
-
-        <p class="disclaimer">
-          COVID Shield is provided as a reference for your local public health authority to build their own app. If you are interested in using COVID Shield, please contact your local government representative and ask what they are doing about exposure notification for COVID-19.
-        </p>
 
         <p>
           COVID Shield is a private, secure, and easy-to-use tool to help
@@ -159,7 +165,7 @@
           </p>
           <p>
             <a class="button button--inverted" href="privacy.html"
-              >Read our privacy policy</a
+              >Read our sample privacy policy</a
             >
           </p>
         </div>


### PR DESCRIPTION
This PR takes the feedback from #15 and implements it in a slightly different way.

The goal is to reduce confusion from the general public about whether COVID Shield is an available app.

![image](https://user-images.githubusercontent.com/447683/82765301-991a5c00-9de3-11ea-92a1-06583c4a92f7.png)

(This closes #15)